### PR TITLE
Correct build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Enter the provider directory and build the provider
 
 ```sh
 $ cd $GOPATH/src/github.com/oogway/terraform-provider-papertrail
-$ make build
+$ go get
+$ go build
 ```
 
 For Usage, have a look at docs in `website` directory.


### PR DESCRIPTION
There's no Makefile in the project. I suspect you meant to just use "go build". A "go get" command is needed also.